### PR TITLE
--dummy-batch-size 옵션 추가 및 onnx 배치 테스트

### DIFF
--- a/run/onnx_test.py
+++ b/run/onnx_test.py
@@ -1,0 +1,118 @@
+import os
+import sys
+import warnings
+from argparse import ArgumentParser
+from datetime import datetime
+from typing import Tuple, List
+
+import onnxruntime
+
+import numpy as np
+from PIL import Image, ImageOps
+
+warnings.filterwarnings("ignore")
+
+
+def rembg_normalize(
+        img: Image.Image,
+        mean: Tuple[float, float, float],
+        std: Tuple[float, float, float],
+        size: Tuple[int, int],
+) -> np.ndarray:
+    im = img.convert("RGB").resize(size, Image.LANCZOS)
+
+    im_ary = np.array(im)
+    im_ary = im_ary / np.max(im_ary)
+
+    _tmpImg = np.zeros((im_ary.shape[0], im_ary.shape[1], 3))
+    _tmpImg[:, :, 0] = (im_ary[:, :, 0] - mean[0]) / std[0]
+    _tmpImg[:, :, 1] = (im_ary[:, :, 1] - mean[1]) / std[1]
+    _tmpImg[:, :, 2] = (im_ary[:, :, 2] - mean[2]) / std[2]
+
+    _tmpImg = _tmpImg.transpose((2, 0, 1))
+
+    return np.expand_dims(_tmpImg, 0).astype(np.float32)
+
+
+def rembg_batch_normalize(
+        images: List[Image.Image],
+        mean: Tuple[float, float, float],
+        std: Tuple[float, float, float],
+        size: Tuple[int, int],
+) -> np.ndarray:
+    _tmp_images = []
+
+    for img in images:
+        _tmp_img = rembg_normalize(img, mean, std, size)
+        _tmp_images.append(_tmp_img)
+
+    return np.concatenate(_tmp_images)
+
+
+def make_mask_image(ort_out: np.ndarray, image_size: Tuple[int, int]):
+    pred = ort_out[:, :, :]
+
+    ma = np.max(pred)
+    mi = np.min(pred)
+
+    pred = (pred - mi) / (ma - mi)
+    pred = np.squeeze(pred)
+
+    mask = Image.fromarray((pred * 255).astype("uint8"), mode="L")
+    mask = mask.resize(image_size, Image.LANCZOS)
+
+    return mask
+
+
+def assert_all_close(test_image_path, onnx_path, dummy_batch_size):
+    test_image_path = os.path.join(os.path.dirname(__file__), test_image_path)
+    test_image = ImageOps.exif_transpose(Image.open(test_image_path))
+
+    mean = (0.485, 0.456, 0.406)
+    std = (0.229, 0.224, 0.225)
+    size = (1024, 1024)
+
+    feed = rembg_normalize(test_image, mean, std, size)
+    batch_feed = rembg_batch_normalize([test_image] * dummy_batch_size, mean, std, size)
+
+    assert feed.shape[0] == 1
+    assert feed.shape[1:] == (3, 1024, 1024)
+
+    assert batch_feed.shape[0] == dummy_batch_size
+    assert batch_feed.shape[1:] == (3, 1024, 1024)
+
+    st = datetime.now()
+    ort_session = onnxruntime.InferenceSession(onnx_path)
+    print(f"ort session load time : {datetime.now() - st}")
+
+    session_input_name = ort_session.get_inputs()[0].name
+    st = datetime.now()
+    ort_outs = ort_session.run(None, {session_input_name: feed})
+    print(f"single prediction time: {datetime.now() - st}")
+
+    st = datetime.now()
+    batch_ort_outs = ort_session.run(None, {session_input_name: batch_feed})
+    print(f"batch({dummy_batch_size}) prediction time: {datetime.now() - st}")
+
+    print("make base mask")
+    base_mask = make_mask_image(ort_outs[0][0, :, :, :], test_image.size)
+    base_mask.save('mask_single.png')
+
+    print("make batch mask")
+    for i in range(0, dummy_batch_size):
+        batch_mask = make_mask_image(batch_ort_outs[0][i, :, :, :], test_image.size)
+        batch_mask.save(f'mask_batch_{i}.png')
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument('onnx_path', type=str)
+    parser.add_argument('test_image_path', type=str)
+    parser.add_argument('--batch-size', type=int, default=2)
+
+    # python onnx_test.py <file.onnx> --test-batch-size 2
+    args = parser.parse_args([
+        '../onnx/InSPyReNet_XB_10.onnx'
+    ])
+
+    assert_all_close(args.onnx_path, args.test_image_path, args.batch_size)


### PR DESCRIPTION
# 변경 내용
```run/convert_pth2onnx.py``` 실행 시 --dummy-batch-size 가 추가되었습니다. 기본값은 2입니다.
해당 옵션값으로 아래 export 에 사용되는 dummy_input의 shape이 결정됩니다.
```
    torch.onnx.export(
        model,  # Executable model
        dummy_input,  # Model input (tuple or multiple input values are also possible)
        onnx_path,  # onnx final path
        export_params=True,  # Whether to save the trained model weights in the model file
        opset_version=13,  # ONNX version to use when converting the model
        do_constant_folding=True,  # Whether to use constant folding for optimization
        input_names=['input'],  # Name indicating the input value of the model
        output_names=['output'],  # Name indicating the output value of the model
        dynamic_axes={
            'input': {0: 'batch_size'},  # Variable length dimensions
            'output': {0: 'batch_size'}
        }
    )
```

기존에는 1024x1024x3 (np.ones) -> 3x1024x1024 (transform) -> 1x3x1024x1024 (unsqueeze) 로 변경되었습니다
```
    img_np = np.ones((1024, 1024, 3), dtype='uint8')
    img = Image.fromarray(img_np)  # Read image
    x = transform(img)
    x = x.unsqueeze(0)
```

이제 transform (3x1024x1024) -> batch_size x 1024 x 1024 x 3 (torch.stack) 으로 변경됩니다.
```
    img_np = np.ones((dummy_batch_size, 1024, 1024, 3), dtype='uint8')
    img = torch.stack(
        [transform(Image.fromarray(_img_np)) for _img_np in img_np]
    )
    dummy_input = img.to('cpu')
```

# 테스트
```onnx_test.py```에 구현되었습니다. 이 스크립트는 onnx 파일경로와 ```--batch-size`` 를 입력받습니다.
입력은 반드시 export 시 입력한 dummy 와 동일하게 입력해주어야 하는 것 확인했습니다.

## ```--dummy-batch-size 1``` 로 export

dummy-batch-size 를 1로 두고 export 한 경우에는 input은 항상 **1**x3x1024x1024이여야합니다.
|input|shape(1x3x1024x1024)|shape(2x3x1024x1024)|
|---|---|---|
|![image](https://user-images.githubusercontent.com/3478196/232469112-6f0d6e7e-5604-49dc-8b81-b915fd6f915e.png)|![image](https://user-images.githubusercontent.com/3478196/232469224-44179bcd-c035-4e9f-8972-1671feb644ac.png)|![image](https://user-images.githubusercontent.com/3478196/232469257-2e7a3291-cf4f-4feb-aa12-8b5b86accabd.png)|

## ```--dummy-batch-size 2``` 로 export

비슷하게 dummy-batch-size 를 2로 두고 export 한 경우에는 input은 항상 **2**x3x1024x1024이여야합니다.
|input|shape(1x3x1024x1024)|shape(2x3x1024x1024)|
|---|---|---|
|![image](https://user-images.githubusercontent.com/3478196/232469112-6f0d6e7e-5604-49dc-8b81-b915fd6f915e.png)|![mask_single](https://user-images.githubusercontent.com/3478196/232470419-0a89de31-1f5e-42db-8bdd-c8d7d0b47fee.png)|![mask_batch_1](https://user-images.githubusercontent.com/3478196/232470479-e2831bb4-10fd-426f-9fca-2e356ebf3252.png)|

## ```--dummy-batch-size 4``` 로 export

마찬가지로 input shape은 4x3x1024x1024 이여야합니다. 지면이 부족하여 생략하겠습니다. 1x3x1024x1024 ~ 3x3x1024x1024는 위와같이 이상한 결과물이 나옵니다

# 서비스

공개된 github 에서는 자세히 작성하긴 힘듭니다.
간략히 설명드리자면 앞으로는 1, 2, 4, 8로 우선 dummy-batch-size 를 두고 export하고, cargen_serivce 에서 구현될 dynamic batch 에서 적당한 모델을 사용하는 방식으로 해야겠습니다.
이후 작업은 bitbucket에서 다루겠습니다.

# 기타

cuda에서 테스트되지 않았습니다. 과연 이렇게 마스크를 따는게 실제로 cuda에서 시간이 단축되는지는 테스트가 필요합니다.
@sanghyun0927 님께서 ```onnx_test.py``` 돌리실 때 시간이 얼마나 걸리는지 한번 봐주시면 감사하겠습니다.